### PR TITLE
Pin setuptools<60 to avoid numpy.distutils failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools<60",
+    "wheel",
+    "oldest-supported-numpy",
+    "numpy!=1.22.0",
+    "mako",
+]


### PR DESCRIPTION
Otherwise fails with `ModuleNotFoundError: No module named 'distutils.msvccompiler'`

See https://gitlab.tiker.net/inducer/sumpy/-/jobs/445670/raw