### PR TITLE
Build with meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,38 @@
+project('pyfmmlib', 'c',
+  version : '0.1',
+  license: 'MIT',
+  meson_version: '>=0.64.0',
+  default_options : ['warning_level=2'],
+)
+
+add_languages('fortran')
+
+py_mod = import('python')
+py = py_mod.find_installation(pure: false)
+py_dep = py.dependency()
+
+incdir_numpy = run_command(py,
+  ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
+  check : true
+).stdout().strip()
+
+incdir_f2py = run_command(py,
+    ['-c', 'import os; os.chdir(".."); import numpy.f2py; print(numpy.f2py.get_include())'],
+    check : true
+).stdout().strip()
+
+fibby_source = custom_target('fibbymodule.c',
+  input : ['fib1.f'],
+  output : ['fibbymodule.c', 'fibby-f2pywrappers.f'],
+  command : [py, '-m', 'numpy.f2py', '@INPUT@', '-m', 'fibby', '--lower']
+)
+
+inc_np = include_directories(incdir_numpy, incdir_f2py)
+
+py.extension_module('_internal',
+  ['fib1.f', fibby_source],
+  incdir_f2py / 'fortranobject.c',
+  include_directories: inc_np,
+  dependencies : py_dep,
+  install : true
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,36 @@
 [build-system]
+build-backend = "mesonpy"
 requires = [
-    "setuptools<60",
-    "wheel",
-    "oldest-supported-numpy",
-    "numpy!=1.22.0",
-    "mako",
+        "meson-python",
+        "oldest-supported-numpy",
+        "numpy!=1.22.0",
+        "mako"]
+
+[project]
+name = "pyfmmlib"
+version = "2023.1"
+description = "Python wrappers for particle FMMs"
+readme = "README.rst"
+requires-python = ">=3.8"
+authors = [
+  {name = "Leslie Greengard"},
+  {name = "Zydrunas Gimbutas"},
+  {name = 'Andreas Kloeckner', email="inform@tiker.net"},
 ]
+classifiers = [
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Other Audience",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Fortran",
+        "Programming Language :: Python",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Software Development :: Libraries",
+        ]
+license = "wrapper: MIT/code: 3-clause BSD"
+
+[project.urls]
+homepage = "https://github.com/inducer/pyfmmlib"


### PR DESCRIPTION
This is needed if we would like support for Python 3.12.

See [example to follow](https://numpy.org/doc/stable/f2py/buildtools/meson.html).