### PR TITLE
Generate indirect-many vec wrappers for formmp (P2M)

### DIFF
--- a/vec_wrappers.py
+++ b/vec_wrappers.py
@@ -483,44 +483,47 @@ def gen_vector_wrappers():
 
     # }}}
 
-    # {{{ formta
+    # {{{ formta, formmp
 
-    for dp_or_no in ["", "_dp"]:
-        for dims in [2, 3]:
-            for eqn in [cgh.Laplace(dims), cgh.Helmholtz(dims)]:
-                func_name = f"{eqn.lh_letter()}{dims}dformta{dp_or_no}"
-                gen_vector_wrapper(func_name,
-                Template("""
-                        integer ier(nvcount)
-                        % if eqn.lh_letter() == "h":
-                            complex *16 zk
-                        % endif
-                        real *8 rscale
-                        real *8 sources(${dims}, *INDIRECT_MANY)
+    # P2L (formta) and P2M (formmp) share identical argument patterns
+    # in fmmlib, so both get the same indirect-many wrappers.
+    for form_what in ["formta", "formmp"]:
+        for dp_or_no in ["", "_dp"]:
+            for dims in [2, 3]:
+                for eqn in [cgh.Laplace(dims), cgh.Helmholtz(dims)]:
+                    func_name = f"{eqn.lh_letter()}{dims}d{form_what}{dp_or_no}"
+                    gen_vector_wrapper(func_name,
+                    Template("""
+                            integer ier(nvcount)
+                            % if eqn.lh_letter() == "h":
+                                complex *16 zk
+                            % endif
+                            real *8 rscale
+                            real *8 sources(${dims}, *INDIRECT_MANY)
 
-                        % if dp_or_no:
-                            complex *16 dipstr(*INDIRECT_MANY)
-                            %if not (eqn.lh_letter() == "l" and dims == 2):
-                                real *8 dipvec(${dims}, *INDIRECT_MANY)
-                            %endif
-                        % else:
-                            complex *16 charge(*INDIRECT_MANY)
-                        % endif
+                            % if dp_or_no:
+                                complex *16 dipstr(*INDIRECT_MANY)
+                                %if not (eqn.lh_letter() == "l" and dims == 2):
+                                    real *8 dipvec(${dims}, *INDIRECT_MANY)
+                                %endif
+                            % else:
+                                complex *16 charge(*INDIRECT_MANY)
+                            % endif
 
-                        integer nsources(*INDIRECT_MANY)
-                        real *8 centers(${dims}, *INDIRECT)
-                        integer nterms
-                        complex *16 expn(${eqn.expansion_dims("nterms")}, nvcount)
-                        """, strict_undefined=True).render(
-                            dims=dims,
-                            eqn=eqn,
-                            dp_or_no=dp_or_no,
-                            ),
-                        ["ier", "expn"],
-                        output_reductions={"expn": "sum", "ier": "max"},
-                        tmp_init={"ier": "0"},
-                        vec_func_name=f"{func_name}_imany",
-                        out_only_args=("ier", "expn"))
+                            integer nsources(*INDIRECT_MANY)
+                            real *8 centers(${dims}, *INDIRECT)
+                            integer nterms
+                            complex *16 expn(${eqn.expansion_dims("nterms")}, nvcount)
+                            """, strict_undefined=True).render(
+                                dims=dims,
+                                eqn=eqn,
+                                dp_or_no=dp_or_no,
+                                ),
+                            ["ier", "expn"],
+                            output_reductions={"expn": "sum", "ier": "max"},
+                            tmp_init={"ier": "0"},
+                            vec_func_name=f"{func_name}_imany",
+                            out_only_args=("ier", "expn"))
 
     # }}}
 


### PR DESCRIPTION
## What

fmmlib's `formmp` routines (P2M) share their argument patterns exactly with `formta` (P2L) — `(ier, [zk,] rscale, sources, charge|dipstr[,dipvec], ns, center, nterms, expn)` in all eight variants — but only `formta` had generated `_imany` wrappers. Downstream drivers (e.g. boxtree's `pyfmmlib_integration.FMMLibExpansionWrangler.form_multipoles`) therefore form multipoles in a Python loop over per-box scalar `formmp` calls, which is serial and call-overhead-bound.

This PR generalizes the `formta` wrapper block in `vec_wrappers.py` to also emit `{l,h}{2,3}dformmp[_dp]_imany` with the same indirect-many addressing, `sum` output reduction, and OpenMP annotations. No hand-written Fortran; purely the existing generator applied to the twin routine family.

## Verification

- Bit-exact against per-box scalar `formmp` loops (0.0 max relative error) for 3D Laplace, 3D Helmholtz, and 2D Laplace on ragged per-box source counts (3–40 sources/box, 50 boxes).
- With OpenMP enabled (see #93), a 4000-box batch with 27 sources/box at `nterms=20` runs 0.26 s → 0.11 s at 4 threads (4C/8T i7-8650U), identical checksums.

Complementary to #93 (which restores the OpenMP flags these annotations need); independent to merge in either order.

A follow-up in boxtree could switch `form_multipoles` to this wrapper; happy to send that separately if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYp74e5ZTE6ZHDNR3ETgM6